### PR TITLE
msm8996: Fix cmd panel include to allow second screen enable

### DIFF
--- a/arch/arm64/boot/dts/lge/msm8996-elsa_att_us/msm8996-elsa_att_us-panel.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_att_us/msm8996-elsa_att_us-panel.dtsi
@@ -14,7 +14,7 @@
 #include "../dsi-panel-lgd-lg4945-dualmipi-qhd-cmd.dtsi"
 #include "../dsi-panel-lgd-lg4946-dualmipi-qhd-cmd.dtsi"
 #include "../dsi-panel-lgd-td4302-dualmipi-qhd-cmd.dtsi"
-#include "../dsi-panel-sw49407-dsc-qhd-cmd_old.dtsi"
+#include "../dsi-panel-sw49407-dsc-qhd-cmd-us_carrier.dtsi"
 #include "../dsi-panel-sw49407-dsc-qhd-video.dtsi"
 
 #include "../msm8992-panel-backlight-lm3697.dtsi"

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_spr_us/msm8996-elsa_spr_us-panel.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_spr_us/msm8996-elsa_spr_us-panel.dtsi
@@ -14,7 +14,7 @@
 #include "../dsi-panel-lgd-lg4945-dualmipi-qhd-cmd.dtsi"
 #include "../dsi-panel-lgd-lg4946-dualmipi-qhd-cmd.dtsi"
 #include "../dsi-panel-lgd-td4302-dualmipi-qhd-cmd.dtsi"
-#include "../dsi-panel-sw49407-dsc-qhd-cmd_old.dtsi"
+#include "../dsi-panel-sw49407-dsc-qhd-cmd-us_carrier.dtsi"
 #include "../dsi-panel-sw49407-dsc-qhd-video.dtsi"
 
 #include "../msm8992-panel-backlight-lm3697.dtsi"

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_vzw/msm8996-elsa_vzw-panel.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_vzw/msm8996-elsa_vzw-panel.dtsi
@@ -14,7 +14,7 @@
 #include "../dsi-panel-lgd-lg4945-dualmipi-qhd-cmd.dtsi"
 #include "../dsi-panel-lgd-lg4946-dualmipi-qhd-cmd.dtsi"
 #include "../dsi-panel-lgd-td4302-dualmipi-qhd-cmd.dtsi"
-#include "../dsi-panel-sw49407-dsc-qhd-cmd_old.dtsi"
+#include "../dsi-panel-sw49407-dsc-qhd-cmd-us_carrier.dtsi"
 #include "../dsi-panel-sw49407-dsc-qhd-video.dtsi"
 
 #include "../msm8992-panel-backlight-lm3697.dtsi"


### PR DESCRIPTION
* h910/ls997/vs995 reverted back to old cmd panel, this fixes it

Change-Id: I49f3350b1164059eb5b1f55c824244eeb199a590